### PR TITLE
Added submenuIf()

### DIFF
--- a/src/Menu.php
+++ b/src/Menu.php
@@ -195,6 +195,22 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
 
         return $this->add($menu->prependIf($header, $header));
     }
+    
+    /**
+     * @param bool $condition
+     * @param callable|\Spatie\Menu\Menu|\Spatie\Menu\Item $header
+     * @param callable|\Spatie\Menu\Menu|null $menu
+     *
+     * @return $this
+     */
+    public function submenuIf($condition, $header, $menu = null)
+    {
+        if ($condition) {
+            $this->submenu($header, $menu);
+        }
+
+        return $this;
+    }
 
     protected function parseSubmenuArgs($args): array
     {


### PR DESCRIPTION
`submenuIfCan()` isn't what I need in the Laravel package. In my code, I want to do `Menu::new()->submenuIf(auth()->check()...`. As it could be used outside Laravel, I PR this in the general package.