### PR TITLE
Fixed startswith bug for active menus

### DIFF
--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -41,4 +41,13 @@ class Str
 
         return $pattern.$subject;
     }
+
+    public static function ensureRight(string $pattern, string $subject): string
+    {
+        if (strrpos($subject, $pattern) === strlen($subject) - 1) {
+            return $subject;
+        }
+
+        return $subject.$pattern;
+    }
 }

--- a/src/Traits/Activatable.php
+++ b/src/Traits/Activatable.php
@@ -97,16 +97,25 @@ trait Activatable
         }
 
         $root = Str::ensureLeft('/', $root);
+        
+        // All paths used in this method should be terminated by a /
+        // otherwise startsWith at the end will be too greedy and
+        // also matches items which are on the same level
+        $root = Str::ensureRight('/', $root);
+
+        $itemPath = Str::ensureRight('/', $itemUrl->getPath());
 
         // If this url doesn't start with the root, it's inactive.
-        if (! Str::startsWith($itemUrl->getPath(), $root)) {
+        if (! Str::startsWith($itemPath, $root)) {
             return $this->setInactive();
         }
 
+        $matchPath = Str::ensureRight('/', $matchUrl->getPath());
+
         // For the next comparisons we just need the paths, and we'll remove
         // the root first.
-        $itemPath = Str::removeFromStart($root, $itemUrl->getPath());
-        $matchPath = Str::removeFromStart($root, $matchUrl->getPath());
+        $itemPath = Str::removeFromStart($root, $itemPath);
+        $matchPath = Str::removeFromStart($root, $matchPath);
 
         // If this url starts with the url we're matching with, it's active.
         if ($matchPath === $itemPath || Str::startsWith($matchPath, $itemPath)) {

--- a/tests/MenuSetActiveTest.php
+++ b/tests/MenuSetActiveTest.php
@@ -50,6 +50,28 @@ class MenuSetActiveTest extends MenuTestCase
     }
 
     /** @test */
+    public function it_can_set_items_active_while_items_exists_with_startswith_true()
+    {
+        $this->menu = Menu::new()
+            ->link('http://example.com', 'Home')
+            ->link('http://example.com/disclaimer', 'Disclaimer')
+            ->link('http://example.com/disclaimer-full', 'Full Disclaimer')
+            ->setActive('http://example.com/disclaimer-full');
+
+        $this->assertRenders('
+            <ul>
+                <li><a href="http://example.com">Home</a></li>
+                <li>
+                    <a href="http://example.com/disclaimer">Disclaimer</a>
+                </li>
+                <li class="active">
+                    <a href="http://example.com/disclaimer-full">Full Disclaimer</a>
+                </li>
+            </ul>
+        ');
+    }
+
+    /** @test */
     public function it_can_set_items_active_with_an_absolute_url()
     {
         $this->menu = Menu::new()
@@ -184,6 +206,24 @@ class MenuSetActiveTest extends MenuTestCase
             <ul>
                 <li><a href="/nl">Home</a></li>
                 <li class="active"><a href="/nl/disclaimer">Disclaimer</a></li>
+                <li><a href="/nl/disclaimer/intellectuele-eigendom">Intellectuële Eigendom</a></li>
+            </ul>
+        ');
+    }
+
+    /** @test */
+    public function and_we_can_still_set_the_root_as_active()
+    {
+        $this->menu = Menu::new()
+            ->link('/nl', 'Home')
+            ->link('/nl/disclaimer', 'Disclaimer')
+            ->link('/nl/disclaimer/intellectuele-eigendom', 'Intellectuële Eigendom')
+            ->setActive('/nl/', '/nl');
+
+        $this->assertRenders('
+            <ul>
+                <li class="active"><a href="/nl">Home</a></li>
+                <li><a href="/nl/disclaimer">Disclaimer</a></li>
                 <li><a href="/nl/disclaimer/intellectuele-eigendom">Intellectuële Eigendom</a></li>
             </ul>
         ');


### PR DESCRIPTION
There was a bug in `determineActiveForUrl` which caused menu items that starts with the same name as another selected menu items to also be set as active. E.g given a menu tree with items `http://example.com/disclaimer` and `http://example.com/disclaimer-full`, both items were set as active when `http://example.com/disclaimer-full` was selected.

The idea of using startsWith is to make sure that all parents from the active menu item are also active. This commit fixes the issue by appending a slash to all paths so only fully matching (parent) menu items are set as active.