### PR TITLE
Allow condition to be callable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
         }
     },
     "autoload-dev": {
+        "files": [
+            "tests/callables.php"
+        ],
         "psr-4": {
             "Spatie\\Menu\\Test\\": "tests"
         }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Menu;
 
-use Closure;
 use Countable;
 use Spatie\Menu\Helpers\Arr;
 use Spatie\HtmlElement\Attributes;

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Menu;
 
+use Closure;
 use Countable;
 use Spatie\Menu\Helpers\Arr;
 use Spatie\HtmlElement\Attributes;
@@ -118,7 +119,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
      */
     public function addIf($condition, Item $item)
     {
-        if ($condition) {
+        if ($this->resolveCondition($condition)) {
             $this->add($item);
         }
 
@@ -149,7 +150,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
      */
     public function linkIf($condition, string $url, string $text)
     {
-        if ($condition) {
+        if ($this->resolveCondition($condition)) {
             $this->link($url, $text);
         }
 
@@ -180,11 +181,20 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
      */
     public function htmlIf($condition, string $html, array $parentAttributes = [])
     {
-        if ($condition) {
+        if ($this->resolveCondition($condition)) {
             $this->html($html, $parentAttributes);
         }
 
         return $this;
+    }
+
+    /**
+     * @param $conditional
+     * @return bool
+     */
+    protected function resolveCondition($conditional)
+    {
+        return $conditional instanceof Closure ? $conditional() : $conditional;
     }
 
     /**

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -194,7 +194,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
      */
     protected function resolveCondition($conditional)
     {
-        return $conditional instanceof Closure ? $conditional() : $conditional;
+        return is_callable($conditional) ? $conditional() : $conditional;
     }
 
     /**

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -365,9 +365,9 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
      *
      * @return $this
      */
-    public function prependIf(bool $condition, string $prepend)
+    public function prependIf($condition, string $prepend)
     {
-        if ($condition) {
+        if ($this->resolveCondition($condition)) {
             return $this->prepend($prepend);
         }
 
@@ -397,9 +397,9 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
      *
      * @return static
      */
-    public function appendIf(bool $condition, string $append)
+    public function appendIf($condition, string $append)
     {
-        if ($condition) {
+        if ($this->resolveCondition($condition)) {
             return $this->append($append);
         }
 

--- a/tests/MenuAddTest.php
+++ b/tests/MenuAddTest.php
@@ -111,8 +111,12 @@ class MenuAddTest extends MenuTestCase
         $this->menu = Menu::new()
             ->addIf(true, Link::to('#', 'Foo'))
             ->addIf(false, Link::to('#', 'Bar'))
-            ->addIf(function () { return true; }, Link::to('#', 'Baz'))
-            ->addIf(function () { return false; }, Link::to('#', 'Qux'));
+            ->addIf(function () {
+                return true;
+            }, Link::to('#', 'Baz'))
+            ->addIf(function () {
+                return false;
+            }, Link::to('#', 'Qux'));
 
         $this->assertRenders('
             <ul>
@@ -128,8 +132,12 @@ class MenuAddTest extends MenuTestCase
         $this->menu = Menu::new()
             ->linkIf(true, '#', 'Foo')
             ->linkIf(false, '#', 'Bar')
-            ->linkIf(function () { return true; }, '#', 'Baz')
-            ->linkIf(function () { return false; }, '#', 'Qux');
+            ->linkIf(function () {
+                return true;
+            }, '#', 'Baz')
+            ->linkIf(function () {
+                return false;
+            }, '#', 'Qux');
 
         $this->assertRenders('
             <ul>
@@ -145,8 +153,12 @@ class MenuAddTest extends MenuTestCase
         $this->menu = Menu::new()
             ->htmlIf(true, 'Foo')
             ->htmlIf(false, 'Bar')
-            ->htmlIf(function () { return true; }, 'Baz')
-            ->htmlIf(function () { return false; }, 'Qux');
+            ->htmlIf(function () {
+                return true;
+            }, 'Baz')
+            ->htmlIf(function () {
+                return false;
+            }, 'Qux');
 
         $this->assertRenders('
             <ul>

--- a/tests/MenuAddTest.php
+++ b/tests/MenuAddTest.php
@@ -116,12 +116,15 @@ class MenuAddTest extends MenuTestCase
             }, Link::to('#', 'Baz'))
             ->addIf(function () {
                 return false;
-            }, Link::to('#', 'Qux'));
+            }, Link::to('#', 'Qux'))
+            ->addIf('is_true', Link::to('#', 'Quux'))
+            ->addIf('is_false', Link::to('#', 'Quuz'));
 
         $this->assertRenders('
             <ul>
                 <li><a href="#">Foo</a></li>
                 <li><a href="#">Baz</a></li>
+                <li><a href="#">Quux</a></li>
             </ul>
         ');
     }
@@ -137,12 +140,15 @@ class MenuAddTest extends MenuTestCase
             }, '#', 'Baz')
             ->linkIf(function () {
                 return false;
-            }, '#', 'Qux');
+            }, '#', 'Qux')
+            ->linkIf('is_true', '#', 'Quux')
+            ->linkIf('is_false', '#', 'Quuz');
 
         $this->assertRenders('
             <ul>
                 <li><a href="#">Foo</a></li>
                 <li><a href="#">Baz</a></li>
+                <li><a href="#">Quux</a></li>
             </ul>
         ');
     }
@@ -158,12 +164,15 @@ class MenuAddTest extends MenuTestCase
             }, 'Baz')
             ->htmlIf(function () {
                 return false;
-            }, 'Qux');
+            }, 'Qux')
+            ->htmlIf('is_true', 'Quux')
+            ->htmlIf('is_false', 'Quuz');
 
         $this->assertRenders('
             <ul>
                 <li>Foo</li>
                 <li>Baz</li>
+                <li>Quux</li>
             </ul>
         ');
     }

--- a/tests/MenuAddTest.php
+++ b/tests/MenuAddTest.php
@@ -110,11 +110,14 @@ class MenuAddTest extends MenuTestCase
     {
         $this->menu = Menu::new()
             ->addIf(true, Link::to('#', 'Foo'))
-            ->addIf(false, Link::to('#', 'Bar'));
+            ->addIf(false, Link::to('#', 'Bar'))
+            ->addIf(function () { return true; }, Link::to('#', 'Baz'))
+            ->addIf(function () { return false; }, Link::to('#', 'Qux'));
 
         $this->assertRenders('
             <ul>
                 <li><a href="#">Foo</a></li>
+                <li><a href="#">Baz</a></li>
             </ul>
         ');
     }
@@ -124,11 +127,14 @@ class MenuAddTest extends MenuTestCase
     {
         $this->menu = Menu::new()
             ->linkIf(true, '#', 'Foo')
-            ->linkIf(false, '#', 'Bar');
+            ->linkIf(false, '#', 'Bar')
+            ->linkIf(function () { return true; }, '#', 'Baz')
+            ->linkIf(function () { return false; }, '#', 'Qux');
 
         $this->assertRenders('
             <ul>
                 <li><a href="#">Foo</a></li>
+                <li><a href="#">Baz</a></li>
             </ul>
         ');
     }
@@ -138,11 +144,14 @@ class MenuAddTest extends MenuTestCase
     {
         $this->menu = Menu::new()
             ->htmlIf(true, 'Foo')
-            ->htmlIf(false, 'Bar');
+            ->htmlIf(false, 'Bar')
+            ->htmlIf(function () { return true; }, 'Baz')
+            ->htmlIf(function () { return false; }, 'Qux');
 
         $this->assertRenders('
             <ul>
                 <li>Foo</li>
+                <li>Baz</li>
             </ul>
         ');
     }

--- a/tests/MenuExtraHtmlTest.php
+++ b/tests/MenuExtraHtmlTest.php
@@ -26,6 +26,8 @@ class MenuExtraHtmlTest extends MenuTestCase
             [function () {
                 return false;
             }, '<h1>Hi!</h1>', '<ul></ul>'],
+            ['is_true', '<h1>Hi!</h1>', '<h1>Hi!</h1><ul></ul>'],
+            ['is_false', '<h1>Hi!</h1>', '<ul></ul>'],
         ];
     }
 
@@ -62,6 +64,8 @@ class MenuExtraHtmlTest extends MenuTestCase
             [function () {
                 return false;
             }, '<aside>Bye!</aside>', '<ul></ul>'],
+            ['is_true', '<aside>Bye!</aside>', '<ul></ul><aside>Bye!</aside>'],
+            ['is_false', '<aside>Bye!</aside>', '<ul></ul>'],
         ];
     }
 

--- a/tests/MenuExtraHtmlTest.php
+++ b/tests/MenuExtraHtmlTest.php
@@ -15,12 +15,60 @@ class MenuExtraHtmlTest extends MenuTestCase
         $this->assertRenders('<h1>Hi!</h1><ul></ul>');
     }
 
+    public function prependIfDataProvider()
+    {
+        return [
+            [true, '<h1>Hi!</h1>', '<h1>Hi!</h1><ul></ul>'],
+            [false, '<h1>Hi!</h1>', '<ul></ul>'],
+            [function () { return true; }, '<h1>Hi!</h1>', '<h1>Hi!</h1><ul></ul>'],
+            [function () { return false; }, '<h1>Hi!</h1>', '<ul></ul>'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider prependIfDataProvider
+     * @param \Closure|bool $condition
+     * @param string $prepend
+     * @param string $expected
+     */
+    public function it_can_conditionally_prepend_content($condition, string $prepend, string $expected)
+    {
+        $this->menu = Menu::new()->prependIf($condition, $prepend);
+
+        $this->assertRenders($expected);
+    }
+
     /** @test */
     public function it_can_append_content()
     {
         $this->menu = Menu::new()->append('<aside>Bye!</aside>');
 
         $this->assertRenders('<ul></ul><aside>Bye!</aside>');
+    }
+
+    public function appendIfDataProvider()
+    {
+        return [
+            [true, '<aside>Bye!</aside>', '<ul></ul><aside>Bye!</aside>'],
+            [false, '<aside>Bye!</aside>', '<ul></ul>'],
+            [function () { return true; }, '<aside>Bye!</aside>', '<ul></ul><aside>Bye!</aside>'],
+            [function () { return false; }, '<aside>Bye!</aside>', '<ul></ul>'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider appendIfDataProvider
+     * @param \Closure|bool $condition
+     * @param string $prepend
+     * @param string $expected
+     */
+    public function it_can_conditionally_append_content($condition, string $prepend, string $expected)
+    {
+        $this->menu = Menu::new()->appendIf($condition, $prepend);
+
+        $this->assertRenders($expected);
     }
 
     /** @test */

--- a/tests/MenuExtraHtmlTest.php
+++ b/tests/MenuExtraHtmlTest.php
@@ -20,8 +20,12 @@ class MenuExtraHtmlTest extends MenuTestCase
         return [
             [true, '<h1>Hi!</h1>', '<h1>Hi!</h1><ul></ul>'],
             [false, '<h1>Hi!</h1>', '<ul></ul>'],
-            [function () { return true; }, '<h1>Hi!</h1>', '<h1>Hi!</h1><ul></ul>'],
-            [function () { return false; }, '<h1>Hi!</h1>', '<ul></ul>'],
+            [function () {
+                return true;
+            }, '<h1>Hi!</h1>', '<h1>Hi!</h1><ul></ul>'],
+            [function () {
+                return false;
+            }, '<h1>Hi!</h1>', '<ul></ul>'],
         ];
     }
 
@@ -52,8 +56,12 @@ class MenuExtraHtmlTest extends MenuTestCase
         return [
             [true, '<aside>Bye!</aside>', '<ul></ul><aside>Bye!</aside>'],
             [false, '<aside>Bye!</aside>', '<ul></ul>'],
-            [function () { return true; }, '<aside>Bye!</aside>', '<ul></ul><aside>Bye!</aside>'],
-            [function () { return false; }, '<aside>Bye!</aside>', '<ul></ul>'],
+            [function () {
+                return true;
+            }, '<aside>Bye!</aside>', '<ul></ul><aside>Bye!</aside>'],
+            [function () {
+                return false;
+            }, '<aside>Bye!</aside>', '<ul></ul>'],
         ];
     }
 

--- a/tests/callables.php
+++ b/tests/callables.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @return bool
+ */
+function is_true()
+{
+    return true;
+}
+
+/**
+ * @return bool
+ */
+function is_false()
+{
+    return false;
+}


### PR DESCRIPTION
This change allows the conditional passed to the conditional methods (`addIf`, `linkIf`, `htmlIf`, `prependIf` and `appendIf`) to be a callable.