### PR TITLE
Feature empty item support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Menu::new()
     <li><a href="/">Home</a></li>
     <li><a href="/about">About</a></li>
     <li><a href="/contact">Contact</a></li>
+    <li></li>
 </ul>
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Menu::new()
     ->add(Link::to('/', 'Home'))
     ->add(Link::to('/about', 'About'))
     ->add(Link::to('/contact', 'Contact'))
+    ->add(Html::empty())
     ->render();
 
 // Or just...
@@ -30,6 +31,7 @@ Menu::new()
     ->link('/', 'Home')
     ->link('/about', 'About')
     ->link('/contact', 'Contact')
+    ->empty()
 ```
 
 ```html

--- a/src/Html.php
+++ b/src/Html.php
@@ -44,6 +44,16 @@ class Html implements Item, Activatable, HasParentAttributes
     }
 
     /**
+     * Create an empty item.
+     *
+     * @return static
+     */
+    public static function empty()
+    {
+        return new static('');
+    }
+
+    /**
      * @return string
      */
     public function html(): string

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -140,6 +140,16 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     }
 
     /**
+     * Shortcut function to add an empty item to the menu.
+     *
+     * @return $this
+     */
+    public function empty()
+    {
+        return $this->add(Html::empty());
+    }
+
+    /**
      * Add a link to the menu if a (non-strict) condition is met.
      *
      * @param bool   $condition

--- a/tests/Items/HtmlTest.php
+++ b/tests/Items/HtmlTest.php
@@ -14,4 +14,13 @@ class HtmlTest extends \PHPUnit_Framework_TestCase
             Html::raw('Hello world')->html()
         );
     }
+
+    /** @test */
+    public function it_can_make_an_empty_item()
+    {
+        $this->assertEquals(
+            '',
+            Html::empty()->html()
+        );
+    }
 }

--- a/tests/MenuAddTest.php
+++ b/tests/MenuAddTest.php
@@ -40,6 +40,18 @@ class MenuAddTest extends MenuTestCase
     }
 
     /** @test */
+    public function an_empty_item_can_be_added()
+    {
+        $this->menu = Menu::new()->empty();
+
+        $this->assertRenders('
+            <ul>
+                <li></li>
+            </ul>
+        ');
+    }
+
+    /** @test */
     public function multiple_items_can_be_added()
     {
         $this->menu = Menu::new()


### PR DESCRIPTION
Resolves #40

I chose to call the helper method in `Menu.php` `empty()`. That can be
confusing but I thought you'd like the lower case trend in your methods.
If you want, I can change it to `emptyItem()`.