### PR TITLE
Allow filters to be invokable classes

### DIFF
--- a/src/Helpers/Reflection.php
+++ b/src/Helpers/Reflection.php
@@ -10,11 +10,18 @@ class Reflection
 {
     public static function firstParameterType(callable $callable): string
     {
-        $reflection = new ReflectionFunction($callable);
+        // # 58 - Allow invokable classes to be used as filters
+        if (is_object($callable)) {
+            $reflection = new \ReflectionObject($callable);
+            $parameters = $reflection->getMethod('__invoke')->getParameters();
+        } else {
+            $reflection = new ReflectionFunction($callable);
+            $parameters = $reflection->getParameters();
+        }
 
         $parameterTypes = array_map(function (ReflectionParameter $parameter) {
             return $parameter->getClass() ? $parameter->getClass()->name : null;
-        }, $reflection->getParameters());
+        }, $parameters);
 
         return $parameterTypes[0] ?? '';
     }

--- a/tests/Items/FiltersTest.php
+++ b/tests/Items/FiltersTest.php
@@ -1,0 +1,116 @@
+<?php
+namespace Spatie\Menu\Test\Items;
+
+use Spatie\Menu\Link;
+use Spatie\Menu\Menu;
+use Spatie\Menu\Test\MenuTestCase;
+
+/**
+ * Class FiltersTest
+ * @package Spatie\Menu\Test\Items
+ */
+class FiltersTest extends MenuTestCase
+{
+    /** @test */
+    public function it_can_apply_using_each()
+    {
+        $this->menu = Menu::new()
+            ->link('#', 'Beam')
+            ->link('#', 'Me')
+            ->each(function (Link $link) {
+                $link->addClass('filtered');
+            })
+            ->link('#', 'Up')
+            ->link('#', 'Scotty')
+        ;
+
+        $this->assertRenders('
+            <ul>
+                <li><a href="#" class="filtered">Beam</a></li>
+                <li><a href="#" class="filtered">Me</a></li>
+                <li><a href="#">Up</a></li>
+                <li><a href="#">Scotty</a></li>
+            </ul>
+        ');
+    }
+
+    /** @test */
+    public function it_can_apply_using_register_filter()
+    {
+        $this->menu = Menu::new()
+            ->link('#', 'Beam')
+            ->link('#', 'Me')
+            ->registerFilter(function (Link $link) {
+                $link->addClass('filtered');
+            })
+            ->link('#', 'Up')
+            ->link('#', 'Scotty')
+        ;
+
+        $this->assertRenders('
+            <ul>
+                <li><a href="#">Beam</a></li>
+                <li><a href="#">Me</a></li>
+                <li><a href="#" class="filtered">Up</a></li>
+                <li><a href="#" class="filtered">Scotty</a></li>
+            </ul>
+        ');
+    }
+
+    /** @test */
+    public function it_can_apply_using_apply_to_all()
+    {
+        $this->menu = Menu::new()
+            ->link('#', 'Beam')
+            ->link('#', 'Me')
+            ->applyToAll(function (Link $link) {
+                $link->addClass('filtered');
+            })
+            ->link('#', 'Up')
+            ->link('#', 'Scotty')
+        ;
+
+        $this->assertRenders('
+            <ul>
+                <li><a href="#" class="filtered">Beam</a></li>
+                <li><a href="#" class="filtered">Me</a></li>
+                <li><a href="#" class="filtered">Up</a></li>
+                <li><a href="#" class="filtered">Scotty</a></li>
+            </ul>
+        ');
+    }
+
+    /** @test */
+    public function it_can_register_a_closure_as_a_filter()
+    {
+        $this->menu = Menu::new()->link('#', 'Foo')->applyToAll(function(Link $link) {
+            $link->addClass('filtered');
+        });
+
+        $this->assertRenders('
+            <ul>
+                <li><a href="#" class="filtered">Foo</a></li>
+            </ul>
+        ');
+    }
+
+    /** @test */
+    public function it_can_register_an_invokable_class_as_a_filter()
+    {
+        // Use an anonymous class -- should be identical to a concrete class
+        $invokable_class = new class {
+            public function __invoke(Link $link)
+            {
+                $link->addClass('filtered');
+            }
+        };
+
+        $this->menu = Menu::new()->link('#', 'Foo')->applyToAll($invokable_class);
+
+        $this->assertRenders('
+            <ul>
+                <li><a href="#" class="filtered">Foo</a></li>
+            </ul>
+        ');
+    }
+}

--- a/tests/Items/FiltersTest.php
+++ b/tests/Items/FiltersTest.php
@@ -6,8 +6,7 @@ use Spatie\Menu\Menu;
 use Spatie\Menu\Test\MenuTestCase;
 
 /**
- * Class FiltersTest
- * @package Spatie\Menu\Test\Items
+ * Class FiltersTest.
  */
 class FiltersTest extends MenuTestCase
 {
@@ -21,8 +20,7 @@ class FiltersTest extends MenuTestCase
                 $link->addClass('filtered');
             })
             ->link('#', 'Up')
-            ->link('#', 'Scotty')
-        ;
+            ->link('#', 'Scotty');
 
         $this->assertRenders('
             <ul>
@@ -44,8 +42,7 @@ class FiltersTest extends MenuTestCase
                 $link->addClass('filtered');
             })
             ->link('#', 'Up')
-            ->link('#', 'Scotty')
-        ;
+            ->link('#', 'Scotty');
 
         $this->assertRenders('
             <ul>
@@ -67,8 +64,7 @@ class FiltersTest extends MenuTestCase
                 $link->addClass('filtered');
             })
             ->link('#', 'Up')
-            ->link('#', 'Scotty')
-        ;
+            ->link('#', 'Scotty');
 
         $this->assertRenders('
             <ul>
@@ -83,7 +79,7 @@ class FiltersTest extends MenuTestCase
     /** @test */
     public function it_can_register_a_closure_as_a_filter()
     {
-        $this->menu = Menu::new()->link('#', 'Foo')->applyToAll(function(Link $link) {
+        $this->menu = Menu::new()->link('#', 'Foo')->applyToAll(function (Link $link) {
             $link->addClass('filtered');
         });
 

--- a/tests/Items/FiltersTest.php
+++ b/tests/Items/FiltersTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Spatie\Menu\Test\Items;
 
 use Spatie\Menu\Link;


### PR DESCRIPTION
This addresses the issue I opened at #58.

I added tests for the new patch. I also added tests for the process of applying filters themselves (while I was there). I wasn't sure where those would be best, so I created a new test class. Let me know if you would like these moved.

All in all, it's a pretty simple change :)