### PR TITLE
Add support for Bootstrap 4

### DIFF
--- a/src/Menu.php
+++ b/src/Menu.php
@@ -632,7 +632,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
         if ($item->isActive()) {
             $attributes->addClass($this->activeClass);
 
-            if($this->activeClassOnLink) {
+            if($this->activeClassOnLink && $item instanceof HasHtmlAttributes) {
                 $item->addClass($this->activeClass);
             }
         }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -559,7 +559,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
      * @param $wrapLinksInList
      * @return $this
      */
-    public function setWrapLinksInList(bool $wrapLinksInList)
+    public function wrapLinksInList(bool $wrapLinksInList)
     {
         $this->wrapLinksInList = $wrapLinksInList;
 

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -544,7 +544,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     }
 
     /**
-     * Set tag for items wrapper
+     * Set tag for items wrapper.
      *
      * @param string $tagName
      * @return $this
@@ -557,7 +557,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     }
 
     /**
-     * Set whether links should be wrapped in a list item
+     * Set whether links should be wrapped in a list item.
      *
      * @param $wrapLinksInList
      * @return $this
@@ -570,7 +570,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     }
 
     /**
-     * Set whether active class should (also) be on link
+     * Set whether active class should (also) be on link.
      *
      * @param $activeClassOnLink
      * @return $this
@@ -583,7 +583,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     }
 
     /**
-     * Set whether active class should (also) be on parent
+     * Set whether active class should (also) be on parent.
      *
      * @param $activeClassOnParent
      * @return $this
@@ -646,11 +646,11 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
         $attributes = new Attributes();
 
         if ($item->isActive()) {
-            if($this->activeClassOnParent) {
+            if ($this->activeClassOnParent) {
                 $attributes->addClass($this->activeClass);
             }
 
-            if($this->activeClassOnLink && $item instanceof HasHtmlAttributes) {
+            if ($this->activeClassOnLink && $item instanceof HasHtmlAttributes) {
                 $item->addClass($this->activeClass);
             }
         }
@@ -659,7 +659,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
             $attributes->setAttributes($item->parentAttributes());
         }
 
-        if(! $this->wrapLinksInList) {
+        if (! $this->wrapLinksInList) {
             return $item->render();
         }
 

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -562,7 +562,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
      * @param $wrapLinksInList
      * @return $this
      */
-    public function wrapLinksInList(bool $wrapLinksInList)
+    public function wrapLinksInList(bool $wrapLinksInList = true)
     {
         $this->wrapLinksInList = $wrapLinksInList;
 

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -37,6 +37,9 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     protected $wrapLinksInList = true;
 
     /** @var bool */
+    protected $activeClassOnParent = true;
+
+    /** @var bool */
     protected $activeClassOnLink = false;
 
     /** @var \Spatie\Menu\Html\Attributes */
@@ -580,6 +583,19 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     }
 
     /**
+     * Set whether active class should (also) be on parent
+     *
+     * @param $activeClassOnParent
+     * @return $this
+     */
+    public function setActiveClassOnParent(bool $activeClassOnParent)
+    {
+        $this->activeClassOnParent = $activeClassOnParent;
+
+        return $this;
+    }
+
+    /**
      * @param bool $condition
      * @param callable $callable
      *
@@ -630,7 +646,9 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
         $attributes = new Attributes();
 
         if ($item->isActive()) {
-            $attributes->addClass($this->activeClass);
+            if($this->activeClassOnParent) {
+                $attributes->addClass($this->activeClass);
+            }
 
             if($this->activeClassOnLink && $item instanceof HasHtmlAttributes) {
                 $item->addClass($this->activeClass);

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -575,7 +575,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
      * @param $activeClassOnLink
      * @return $this
      */
-    public function setActiveClassOnLink(bool $activeClassOnLink)
+    public function setActiveClassOnLink(bool $activeClassOnLink = true)
     {
         $this->activeClassOnLink = $activeClassOnLink;
 
@@ -588,7 +588,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
      * @param $activeClassOnParent
      * @return $this
      */
-    public function setActiveClassOnParent(bool $activeClassOnParent)
+    public function setActiveClassOnParent(bool $activeClassOnParent = true)
     {
         $this->activeClassOnParent = $activeClassOnParent;
 

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -557,6 +557,23 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
         return $clone;
     }
 
+    protected $tagName = 'ul';
+    protected $wrapLinksInList = true;
+
+    public function setTagName($tagName)
+    {
+        $this->tagName = $tagName;
+
+        return $this;
+    }
+
+    public function setWrapLinksInList($wrapLinksInList)
+    {
+        $this->wrapLinksInList = $wrapLinksInList;
+
+        return $this;
+    }
+
     /**
      * Render the menu.
      *
@@ -564,7 +581,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
      */
     public function render(): string
     {
-        $tag = new Tag('ul', $this->htmlAttributes);
+        $tag = new Tag($this->tagName, $this->htmlAttributes);
 
         $contents = array_map([$this, 'renderItem'], $this->items);
 
@@ -587,6 +604,10 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
 
         if ($item instanceof HasParentAttributes) {
             $attributes->setAttributes($item->parentAttributes());
+        }
+
+        if(! $this->wrapLinksInList) {
+            return $item->render();
         }
 
         return Tag::make('li', $attributes)->withContents($item->render());

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -30,6 +30,15 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     /** @var string */
     protected $activeClass = 'active';
 
+    /** @var string */
+    protected $tagName = 'ul';
+
+    /** @var bool */
+    protected $wrapLinksInList = true;
+
+    /** @var bool */
+    protected $activeClassOnLink = false;
+
     /** @var \Spatie\Menu\Html\Attributes */
     protected $htmlAttributes, $parentAttributes;
 
@@ -532,6 +541,45 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     }
 
     /**
+     * Set tag for items wrapper
+     *
+     * @param string $tagName
+     * @return $this
+     */
+    public function setTagName(string $tagName)
+    {
+        $this->tagName = $tagName;
+
+        return $this;
+    }
+
+    /**
+     * Set whether links should be wrapped in a list item
+     *
+     * @param $wrapLinksInList
+     * @return $this
+     */
+    public function setWrapLinksInList(bool $wrapLinksInList)
+    {
+        $this->wrapLinksInList = $wrapLinksInList;
+
+        return $this;
+    }
+
+    /**
+     * Set whether active class should (also) be on link
+     *
+     * @param $activeClassOnLink
+     * @return $this
+     */
+    public function setActiveClassOnLink(bool $activeClassOnLink)
+    {
+        $this->activeClassOnLink = $activeClassOnLink;
+
+        return $this;
+    }
+
+    /**
      * @param bool $condition
      * @param callable $callable
      *
@@ -555,23 +603,6 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
         $clone->activeClass = $this->activeClass;
 
         return $clone;
-    }
-
-    protected $tagName = 'ul';
-    protected $wrapLinksInList = true;
-
-    public function setTagName($tagName)
-    {
-        $this->tagName = $tagName;
-
-        return $this;
-    }
-
-    public function setWrapLinksInList($wrapLinksInList)
-    {
-        $this->wrapLinksInList = $wrapLinksInList;
-
-        return $this;
     }
 
     /**
@@ -600,6 +631,10 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
 
         if ($item->isActive()) {
             $attributes->addClass($this->activeClass);
+
+            if($this->activeClassOnLink) {
+                $item->addClass($this->activeClass);
+            }
         }
 
         if ($item instanceof HasParentAttributes) {

--- a/tests/MenuExtraHtmlTest.php
+++ b/tests/MenuExtraHtmlTest.php
@@ -151,4 +151,43 @@ class MenuExtraHtmlTest extends MenuTestCase
             </div>
         ');
     }
+
+    /** @test */
+    public function it_can_render_as_another_tag()
+    {
+        $this->menu = Menu::new()->setTagName('div')->link('#', 'Foo');
+
+        $this->assertRenders('
+            <div>
+                <li><a href="#">Foo</a></li>
+            </div>
+        ');
+    }
+
+    /** @test */
+    public function it_can_render_without_wrapping_links_in_list()
+    {
+        $this->menu = Menu::new()->setWrapLinksInList(false)->link('#', 'Foo');
+
+        $this->assertRenders('
+            <ul>
+                <a href="#">Foo</a>
+            </ul>
+        ');
+    }
+
+    /** @test */
+    public function it_can_render_as_another_tag_without_wrapping_links_in_list()
+    {
+        $this->menu = Menu::new()
+            ->setWrapLinksInList(false)
+            ->setTagName('div')
+            ->link('#', 'Foo');
+
+        $this->assertRenders('
+            <div>
+                <a href="#">Foo</a>
+            </div>
+        ');
+    }
 }

--- a/tests/MenuExtraHtmlTest.php
+++ b/tests/MenuExtraHtmlTest.php
@@ -167,7 +167,7 @@ class MenuExtraHtmlTest extends MenuTestCase
     /** @test */
     public function it_can_render_without_wrapping_links_in_list()
     {
-        $this->menu = Menu::new()->setWrapLinksInList(false)->link('#', 'Foo');
+        $this->menu = Menu::new()->wrapLinksInList(false)->link('#', 'Foo');
 
         $this->assertRenders('
             <ul>
@@ -180,7 +180,7 @@ class MenuExtraHtmlTest extends MenuTestCase
     public function it_can_render_as_another_tag_without_wrapping_links_in_list()
     {
         $this->menu = Menu::new()
-            ->setWrapLinksInList(false)
+            ->wrapLinksInList(false)
             ->setTagName('div')
             ->link('#', 'Foo');
 
@@ -197,7 +197,7 @@ class MenuExtraHtmlTest extends MenuTestCase
         $submenu = Menu::new()
             ->setTagName('div')
             ->addClass('dropdown-menu')
-            ->setWrapLinksInList(false)
+            ->wrapLinksInList(false)
             ->add(Link::to('#', 'Foo')->addParentClass('nav-item')->addClass('dropdown-item'));
 
         $this->menu = Menu::new()

--- a/tests/MenuExtraHtmlTest.php
+++ b/tests/MenuExtraHtmlTest.php
@@ -190,4 +190,33 @@ class MenuExtraHtmlTest extends MenuTestCase
             </div>
         ');
     }
+
+    /** @test */
+    public function it_can_render_as_a_bootstrap_4_menu()
+    {
+        $submenu = Menu::new()
+            ->setTagName('div')
+            ->addClass('dropdown-menu')
+            ->setWrapLinksInList(false)
+            ->add(Link::to('#', 'Foo')->addParentClass('nav-item')->addClass('dropdown-item'));
+
+        $this->menu = Menu::new()
+            ->addClass('navbar-nav')
+            ->add(Link::to('#', 'Foo')->addParentClass('nav-item')->addClass('nav-link'))
+            ->submenu(Link::to('#', 'Dropdown link')->addClass('nav-link dropdown-toggle')->setAttribute('data-toggle', 'dropdown'), $submenu->addParentClass('nav-item dropdown'));
+
+        $this->assertRenders('
+            <ul class="navbar-nav">
+                <li class="nav-item">
+                    <a href="#" class="nav-link">Foo</a>
+                </li>
+                <li class="nav-item dropdown">
+                    <a href="#" data-toggle="dropdown" class="nav-link dropdown-toggle">Dropdown link</a>
+                    <div class="dropdown-menu">
+                        <a href="#" class="dropdown-item">Foo</a>
+                    </div>
+                </li>
+            </ul>
+        ');
+    }
 }

--- a/tests/MenuSetActiveTest.php
+++ b/tests/MenuSetActiveTest.php
@@ -310,4 +310,70 @@ class MenuSetActiveTest extends MenuTestCase
             </div>
         ');
     }
+
+    /** @test */
+    public function it_can_render_active_on_a_bootstrap_4_menu()
+    {
+        $submenu = Menu::new()
+            ->setTagName('div')
+            ->addClass('dropdown-menu')
+            ->setWrapLinksInList(false)
+            ->setActiveClassOnLink(true)
+            ->add(Link::to('/', 'Home')->addParentClass('nav-item')->addClass('dropdown-item'));
+
+        $this->menu = Menu::new()
+            ->addClass('navbar-nav')
+            ->add(Link::to('/about', 'About')->addParentClass('nav-item')->addClass('nav-link'))
+            ->submenu(Link::to('#', 'Dropdown link')->addClass('nav-link dropdown-toggle')->setAttribute('data-toggle', 'dropdown'), $submenu->addParentClass('nav-item dropdown'))
+            ->setActive(function (Link $link) {
+                return $link->url() === '/about';
+            });
+
+        $this->assertRenders('
+            <ul class="navbar-nav">
+                <li class="active nav-item">
+                    <a href="/about" class="nav-link">About</a>
+                </li>
+                <li class="nav-item dropdown">
+                    <a href="#" data-toggle="dropdown" class="nav-link dropdown-toggle">Dropdown link</a>
+                    <div class="dropdown-menu">
+                        <a href="/" class="dropdown-item">Home</a>
+                    </div>
+                </li>
+            </ul>
+        ');
+    }
+
+    /** @test */
+    public function it_can_render_active_on_a_bootstrap_4_submenu()
+    {
+        $submenu = Menu::new()
+            ->setTagName('div')
+            ->addClass('dropdown-menu')
+            ->setWrapLinksInList(false)
+            ->setActiveClassOnLink(true)
+            ->add(Link::to('/about', 'About')->addParentClass('nav-item')->addClass('dropdown-item'));
+
+        $this->menu = Menu::new()
+            ->addClass('navbar-nav')
+            ->add(Link::to('/', 'Home')->addParentClass('nav-item')->addClass('nav-link'))
+            ->submenu(Link::to('#', 'Dropdown link')->addClass('nav-link dropdown-toggle')->setAttribute('data-toggle', 'dropdown'), $submenu->addParentClass('nav-item dropdown'))
+            ->setActive(function (Link $link) {
+                return $link->url() === '/about';
+            });
+
+        $this->assertRenders('
+            <ul class="navbar-nav">
+                <li class="nav-item">
+                    <a href="/" class="nav-link">Home</a>
+                </li>
+                <li class="active nav-item dropdown">
+                    <a href="#" data-toggle="dropdown" class="nav-link dropdown-toggle">Dropdown link</a>
+                    <div class="dropdown-menu">
+                        <a href="/about" class="dropdown-item active">About</a>
+                    </div>
+                </li>
+            </ul>
+        ');
+    }
 }

--- a/tests/MenuSetActiveTest.php
+++ b/tests/MenuSetActiveTest.php
@@ -250,4 +250,64 @@ class MenuSetActiveTest extends MenuTestCase
             </ul>
         ');
     }
+
+    /** @test */
+    public function it_can_render_active_on_custom_tag()
+    {
+        $this->menu = Menu::new()
+            ->setTagName('div')
+            ->link('/', 'Home')
+            ->link('/about', 'About')
+            ->setActive(function (Link $link) {
+                return $link->url() === '/about';
+            });
+
+        $this->assertRenders('
+            <div>
+                <li><a href="/">Home</a></li>
+                <li class="active"><a href="/about">About</a></li>
+            </div>
+        ');
+    }
+
+    /** @test */
+    public function it_can_render_active_without_list_items()
+    {
+        $this->menu = Menu::new()
+            ->setWrapLinksInList(false)
+            ->setActiveClassOnLink(true)
+            ->link('/', 'Home')
+            ->link('/about', 'About')
+            ->setActive(function (Link $link) {
+                return $link->url() === '/about';
+            });
+
+        $this->assertRenders('
+            <ul>
+                <a href="/">Home</a>
+                <a href="/about" class="active">About</a>
+            </ul>
+        ');
+    }
+
+    /** @test */
+    public function it_can_render_active_on_custom_tag_without_list_items()
+    {
+        $this->menu = Menu::new()
+            ->setTagName('div')
+            ->setWrapLinksInList(false)
+            ->setActiveClassOnLink(true)
+            ->link('/', 'Home')
+            ->link('/about', 'About')
+            ->setActive(function (Link $link) {
+                return $link->url() === '/about';
+            });
+
+        $this->assertRenders('
+            <div>
+                <a href="/">Home</a>
+                <a href="/about" class="active">About</a>
+            </div>
+        ');
+    }
 }

--- a/tests/MenuSetActiveTest.php
+++ b/tests/MenuSetActiveTest.php
@@ -274,7 +274,7 @@ class MenuSetActiveTest extends MenuTestCase
     public function it_can_render_active_without_list_items()
     {
         $this->menu = Menu::new()
-            ->setWrapLinksInList(false)
+            ->wrapLinksInList(false)
             ->setActiveClassOnLink(true)
             ->link('/', 'Home')
             ->link('/about', 'About')
@@ -295,7 +295,7 @@ class MenuSetActiveTest extends MenuTestCase
     {
         $this->menu = Menu::new()
             ->setTagName('div')
-            ->setWrapLinksInList(false)
+            ->wrapLinksInList(false)
             ->setActiveClassOnLink(true)
             ->link('/', 'Home')
             ->link('/about', 'About')
@@ -317,7 +317,7 @@ class MenuSetActiveTest extends MenuTestCase
         $submenu = Menu::new()
             ->setTagName('div')
             ->addClass('dropdown-menu')
-            ->setWrapLinksInList(false)
+            ->wrapLinksInList(false)
             ->setActiveClassOnLink(true)
             ->add(Link::to('/', 'Home')->addParentClass('nav-item')->addClass('dropdown-item'));
 
@@ -350,7 +350,7 @@ class MenuSetActiveTest extends MenuTestCase
         $submenu = Menu::new()
             ->setTagName('div')
             ->addClass('dropdown-menu')
-            ->setWrapLinksInList(false)
+            ->wrapLinksInList(false)
             ->setActiveClassOnLink(true)
             ->add(Link::to('/about', 'About')->addParentClass('nav-item')->addClass('dropdown-item'));
 

--- a/tests/MenuSetActiveTest.php
+++ b/tests/MenuSetActiveTest.php
@@ -376,4 +376,27 @@ class MenuSetActiveTest extends MenuTestCase
             </ul>
         ');
     }
+
+    /** @test */
+    public function it_can_have_no_active_class()
+    {
+        $this->menu = Menu::new()
+            ->link('/', 'Home')
+            ->link('/disclaimer', 'Disclaimer')
+            ->link('/disclaimer/intellectual-property', 'Intellectual Property')
+            ->setActiveClassOnParent(false)
+            ->setActive('/disclaimer');
+
+        $this->assertRenders('
+            <ul>
+                <li><a href="/">Home</a></li>
+                <li>
+                    <a href="/disclaimer">Disclaimer</a>
+                </li>
+                <li>
+                    <a href="/disclaimer/intellectual-property">Intellectual Property</a>
+                </li>
+            </ul>
+        ');
+    }
 }


### PR DESCRIPTION
When merged this PR adds support for Bootstrap 4. 

We added 3 new methods for the `Menu` class:

- `setTagName` enables using another element as an `<ul>`
- `setWrapLinksInList` can disable automatic the wrapping of links in `<li>`'s
- `setActiveClassOnLink` can set the `activeClass` on the link instead of the `<li>`

To set the active class on the link we assume that the item supplied to `renderItem` implements `HasHtmlAttributes`. I think it is pretty safe to do so, but to be safe we added a check to see if the item implements `HasHtmlAttributes`.

The syntax to render a Bootstrap 4 menu looks like this:

``` php
$submenu = Menu::new()
    ->setTagName('div')
    ->addClass('dropdown-menu')
    ->setWrapLinksInList(false)
    ->setActiveClassOnLink(true)
    ->add(Link::to('/about', 'About')->addParentClass('nav-item')->addClass('dropdown-item'));

Menu::new()
    ->addClass('navbar-nav')
    ->add(Link::to('/', 'Home')->addParentClass('nav-item')->addClass('nav-link'))
    ->submenu(Link::to('#', 'Dropdown link')->addClass('nav-link dropdown-toggle')->setAttribute('data-toggle', 'dropdown'), $submenu->addParentClass('nav-item dropdown'))
    ->setActive(function (Link $link) {
        return $link->url() === '/about';
    })->render();
```