### PR TITLE
Fix documentation syntax error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Menu::new()
     ->link('/', 'Home')
     ->submenu('More', Menu::new()
         ->addClass('submenu')
-        ->link('/about', 'About'))
-        ->link('/contact', 'Contact'))
+        ->link('/about', 'About')
+        ->link('/contact', 'Contact')
     );
 ```
 


### PR DESCRIPTION
Fix documentation example for "Not Afraid of Depths" section removing extra closing parentheses.