### PR TITLE
Implement exact-active class for exact url matches - resolves #68

### DIFF
--- a/src/ExactUrlChecker.php
+++ b/src/ExactUrlChecker.php
@@ -38,7 +38,7 @@ class ExactUrlChecker
         $itemPath = Str::removeFromStart($rootUrl, $itemPath);
         $matchPath = Str::removeFromStart($rootUrl, $matchPath);
 
-        // If this url starts with the url we're matching with, it's active.
+        // If this url is an exact match for the url we're matching with, it's exact-active.
         if ($matchPath === $itemPath) {
             return true;
         }

--- a/src/ExactUrlChecker.php
+++ b/src/ExactUrlChecker.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Spatie\Menu;
+
+use Spatie\Url\Url;
+use Spatie\Menu\Helpers\Str;
+
+class ExactUrlChecker
+{
+    public static function check(string $url, string $requestUrl, string $rootUrl = '/'): bool
+    {
+        $url = Url::fromString($url);
+        $requestUrl = Url::fromString($requestUrl);
+
+        // If the hosts don't match, this url isn't active.
+        if ($url->getHost() !== $requestUrl->getHost()) {
+            return false;
+        }
+
+        $rootUrl = Str::ensureLeft('/', $rootUrl);
+
+        // All paths used in this method should be terminated by a /
+        // otherwise startsWith at the end will be too greedy and
+        // also matches items which are on the same level
+        $rootUrl = Str::ensureRight('/', $rootUrl);
+
+        $itemPath = Str::ensureRight('/', $url->getPath());
+
+        // If this url doesn't start with the rootUrl, it's inactive.
+        if (! Str::startsWith($itemPath, $rootUrl)) {
+            return false;
+        }
+
+        $matchPath = Str::ensureRight('/', $requestUrl->getPath());
+
+        // For the next comparisons we just need the paths, and we'll remove
+        // the rootUrl first.
+        $itemPath = Str::removeFromStart($rootUrl, $itemPath);
+        $matchPath = Str::removeFromStart($rootUrl, $matchPath);
+
+        // If this url starts with the url we're matching with, it's active.
+        if ($matchPath === $itemPath) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -31,6 +31,9 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     protected $activeClass = 'active';
 
     /** @var string */
+    protected $exactActiveClass = 'exact-active';
+
+    /** @var string */
     protected $wrapperTagName = 'ul';
 
     /** @var bool */
@@ -41,6 +44,9 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
 
     /** @var bool */
     protected $activeClassOnLink = false;
+
+    /** @var bool */
+    protected $exactActive = false;
 
     /** @var \Spatie\Menu\Html\Attributes */
     protected $htmlAttributes, $parentAttributes;
@@ -411,6 +417,34 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     }
 
     /**
+     * Set if the menu should add an extra class for exact url matches.
+     *
+     * @param bool @exactActive
+     *
+     * @return $this
+     */
+    public function setExactActive(bool $exactActive = true)
+    {
+        $this->exactActive = $exactActive;
+
+        return $this;
+    }
+
+    /**
+     * Set the class name that will be used on exact-active items for this menu.
+     *
+     * @param string $class
+     *
+     * @return $this
+     */
+    public function setExactActiveClass(string $class)
+    {
+        $this->exactActiveClass = $class;
+
+        return $this;
+    }
+
+    /**
      * Set all relevant children active based on the current request's URL.
      *
      * /, /about, /contact => request to /about will set the about link active.
@@ -686,10 +720,18 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
         if ($item->isActive()) {
             if ($this->activeClassOnParent) {
                 $attributes->addClass($this->activeClass);
+
+                if ($this->exactActive && $item->isExactActive()) {
+                    $attributes->addClass($this->exactActiveClass);
+                }
             }
 
             if ($this->activeClassOnLink && $item instanceof HasHtmlAttributes) {
                 $item->addClass($this->activeClass);
+
+                if ($this->exactActive && $item->isExactActive()) {
+                    $item->addClass($this->exactActiveClass);
+                }
             }
         }
 

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -45,9 +45,6 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     /** @var bool */
     protected $activeClassOnLink = false;
 
-    /** @var bool */
-    protected $exactActive = false;
-
     /** @var \Spatie\Menu\Html\Attributes */
     protected $htmlAttributes, $parentAttributes;
 
@@ -394,6 +391,16 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     }
 
     /**
+     * A menu can be active but not exact-active.
+     *
+     * @return bool
+     */
+    public function isExactActive(): bool
+    {
+        return false;
+    }
+
+    /**
      * Set multiple items in the menu as active based on a callable that filters
      * through items. If you typehint the item parameter in the callable, it will
      * only be applied to items of that type.
@@ -414,20 +421,6 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
         }
 
         throw new \InvalidArgumentException('`setActive` requires a pattern or a callable');
-    }
-
-    /**
-     * Set if the menu should add an extra class for exact url matches.
-     *
-     * @param bool @exactActive
-     *
-     * @return $this
-     */
-    public function setExactActive(bool $exactActive = true)
-    {
-        $this->exactActive = $exactActive;
-
-        return $this;
     }
 
     /**
@@ -492,6 +485,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
 
             if ($callable($item)) {
                 $item->setActive();
+                $item->setExactActive();
             }
         });
 
@@ -721,7 +715,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
             if ($this->activeClassOnParent) {
                 $attributes->addClass($this->activeClass);
 
-                if ($this->exactActive && $item->isExactActive()) {
+                if ($item->isExactActive()) {
                     $attributes->addClass($this->exactActiveClass);
                 }
             }
@@ -729,7 +723,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
             if ($this->activeClassOnLink && $item instanceof HasHtmlAttributes) {
                 $item->addClass($this->activeClass);
 
-                if ($this->exactActive && $item->isExactActive()) {
+                if ($item->isExactActive()) {
                     $item->addClass($this->exactActiveClass);
                 }
             }

--- a/src/Traits/Activatable.php
+++ b/src/Traits/Activatable.php
@@ -4,6 +4,7 @@ namespace Spatie\Menu\Traits;
 
 use Spatie\Url\Url;
 use Spatie\Menu\ActiveUrlChecker;
+use Spatie\Menu\ExactUrlChecker;
 
 /**
  * Expects an `$active` property on the class.
@@ -91,5 +92,33 @@ trait Activatable
         ActiveUrlChecker::check($this->url, $url, $root)
             ? $this->setActive()
             : $this->setInactive();
+
+        ExactUrlChecker::check($this->url, $url, $root)
+            ? $this->setExactActive()
+            : $this->setExactActive(false);
+    }
+
+    /**
+     * Set if current Activatable should be marked as an exact url match
+     *
+     * @param bool $exactActive
+     *
+     * @return $this
+     */
+    public function setExactActive(bool $exactActive = true)
+    {
+        $this->exactActive = $exactActive;
+
+        return $this;
+    }
+
+    /**
+     * Check if current Activatable is marked as an exact url match
+     *
+     * @return bool
+     */
+    public function isExactActive(): bool
+    {
+        return $this->exactActive;
     }
 }

--- a/src/Traits/Activatable.php
+++ b/src/Traits/Activatable.php
@@ -14,6 +14,11 @@ use Spatie\Menu\ExactUrlChecker;
 trait Activatable
 {
     /**
+     * @var bool
+     */
+    protected $exactActive = false;
+
+    /**
      * @return bool
      */
     public function isActive(): bool

--- a/tests/MenuSetActiveTest.php
+++ b/tests/MenuSetActiveTest.php
@@ -26,6 +26,46 @@ class MenuSetActiveTest extends MenuTestCase
     }
 
     /** @test */
+    public function it_can_set_items_exact_active()
+    {
+        $this->menu = Menu::new()
+            ->setExactActive(true)
+            ->link('/', 'Home')
+            ->link('/people', 'People')
+            ->link('/people/sebastian', 'Sebastian')
+            ->setActive('/people/sebastian');
+
+        $this->assertRenders('
+            <ul>
+                <li><a href="/">Home</a></li>
+                <li class="active"><a href="/people">People</a></li>
+                <li class="active exact-active"><a href="/people/sebastian">Sebastian</a></li>
+            </ul>
+        ');
+    }
+
+    /** @test */
+    public function it_only_sets_exact_active_on_exact_url_match()
+    {
+        $this->menu = Menu::new()
+            ->setExactActive(true)
+            ->link('/', 'Home')
+            ->link('/people', 'People')
+            ->link('/people/sebastian', 'Sebastian')
+            ->link('/people/sebastian/bio', 'Bio')
+            ->setActive('/people/sebastian');
+
+        $this->assertRenders('
+            <ul>
+                <li><a href="/">Home</a></li>
+                <li class="active"><a href="/people">People</a></li>
+                <li class="active exact-active"><a href="/people/sebastian">Sebastian</a></li>
+                <li><a href="/people/sebastian/bio">Bio</a></li>
+            </ul>
+        ');
+    }
+
+    /** @test */
     public function it_can_set_items_active_recursively_through_submenus_with_a_callable()
     {
         $this->menu = Menu::new()
@@ -245,6 +285,30 @@ class MenuSetActiveTest extends MenuTestCase
                     <a href="/disclaimer">Disclaimer</a>
                 </li>
                 <li class="-active">
+                    <a href="/disclaimer/intellectual-property">Intellectual Property</a>
+                </li>
+            </ul>
+        ');
+    }
+
+    /** @test */
+    public function it_can_render_a_custom_exact_active_class()
+    {
+        $this->menu = Menu::new()
+            ->setExactActive()
+            ->setExactActiveClass('e-active')
+            ->link('/', 'Home')
+            ->link('/disclaimer', 'Disclaimer')
+            ->link('/disclaimer/intellectual-property', 'Intellectual Property')
+            ->setActive('/disclaimer');
+
+        $this->assertRenders('
+            <ul>
+                <li><a href="/">Home</a></li>
+                <li class="active e-active">
+                    <a href="/disclaimer">Disclaimer</a>
+                </li>
+                <li>
                     <a href="/disclaimer/intellectual-property">Intellectual Property</a>
                 </li>
             </ul>

--- a/tests/MenuSetActiveTest.php
+++ b/tests/MenuSetActiveTest.php
@@ -20,7 +20,7 @@ class MenuSetActiveTest extends MenuTestCase
         $this->assertRenders('
             <ul>
                 <li><a href="/">Home</a></li>
-                <li class="active"><a href="/about">About</a></li>
+                <li class="active exact-active"><a href="/about">About</a></li>
             </ul>
         ');
     }
@@ -29,7 +29,6 @@ class MenuSetActiveTest extends MenuTestCase
     public function it_can_set_items_exact_active()
     {
         $this->menu = Menu::new()
-            ->setExactActive(true)
             ->link('/', 'Home')
             ->link('/people', 'People')
             ->link('/people/sebastian', 'Sebastian')
@@ -48,7 +47,6 @@ class MenuSetActiveTest extends MenuTestCase
     public function it_only_sets_exact_active_on_exact_url_match()
     {
         $this->menu = Menu::new()
-            ->setExactActive(true)
             ->link('/', 'Home')
             ->link('/people', 'People')
             ->link('/people/sebastian', 'Sebastian')
@@ -82,7 +80,7 @@ class MenuSetActiveTest extends MenuTestCase
                 <li class="active">
                     <ul>
                         <li><a href="/">Home</a></li>
-                        <li class="active"><a href="/about">About</a></li>
+                        <li class="active exact-active"><a href="/about">About</a></li>
                     </ul>
                 </li>
             </ul>
@@ -104,7 +102,7 @@ class MenuSetActiveTest extends MenuTestCase
                 <li>
                     <a href="http://example.com/disclaimer">Disclaimer</a>
                 </li>
-                <li class="active">
+                <li class="active exact-active">
                     <a href="http://example.com/disclaimer-full">Full Disclaimer</a>
                 </li>
             </ul>
@@ -123,7 +121,7 @@ class MenuSetActiveTest extends MenuTestCase
         $this->assertRenders('
             <ul>
                 <li><a href="http://example.com">Home</a></li>
-                <li class="active">
+                <li class="active exact-active">
                     <a href="http://example.com/disclaimer">Disclaimer</a>
                 </li>
                 <li>
@@ -149,7 +147,7 @@ class MenuSetActiveTest extends MenuTestCase
                 <li class="active">
                     <ul>
                         <li><a href="http://example.com">Home</a></li>
-                        <li class="active">
+                        <li class="active exact-active">
                             <a href="http://example.com/disclaimer">Disclaimer</a>
                         </li>
                         <li>
@@ -173,7 +171,7 @@ class MenuSetActiveTest extends MenuTestCase
         $this->assertRenders('
             <ul>
                 <li><a href="/">Home</a></li>
-                <li class="active">
+                <li class="active exact-active">
                     <a href="/disclaimer">Disclaimer</a>
                 </li>
                 <li>
@@ -193,7 +191,7 @@ class MenuSetActiveTest extends MenuTestCase
 
         $this->assertRenders('
             <ul>
-                <li class="active"><a href="https://example.com/foo">Example Foo</a></li>
+                <li class="active exact-active"><a href="https://example.com/foo">Example Foo</a></li>
                 <li><a href="https://another-example.com/foo">Another Example Foo</a></li>
             </ul>
         ');
@@ -209,7 +207,7 @@ class MenuSetActiveTest extends MenuTestCase
 
         $this->assertRenders('
             <ul>
-                <li class="active"><a href="https://example.com/foo">Example Foo</a></li>
+                <li class="active exact-active"><a href="https://example.com/foo">Example Foo</a></li>
                 <li><a href="https://sub.example.com/foo">Sub Example Foo</a></li>
             </ul>
         ');
@@ -227,7 +225,7 @@ class MenuSetActiveTest extends MenuTestCase
         $this->assertRenders('
             <ul>
                 <li><a href="/nl">Home</a></li>
-                <li class="active"><a href="/nl/disclaimer">Disclaimer</a></li>
+                <li class="active exact-active"><a href="/nl/disclaimer">Disclaimer</a></li>
                 <li><a href="/nl/disclaimer/intellectuele-eigendom">Intellectuële Eigendom</a></li>
             </ul>
         ');
@@ -245,7 +243,7 @@ class MenuSetActiveTest extends MenuTestCase
         $this->assertRenders('
             <ul>
                 <li><a href="/nl">Home</a></li>
-                <li class="active"><a href="/nl/disclaimer">Disclaimer</a></li>
+                <li class="active exact-active"><a href="/nl/disclaimer">Disclaimer</a></li>
                 <li><a href="/nl/disclaimer/intellectuele-eigendom">Intellectuële Eigendom</a></li>
             </ul>
         ');
@@ -262,7 +260,7 @@ class MenuSetActiveTest extends MenuTestCase
 
         $this->assertRenders('
             <ul>
-                <li class="active"><a href="/nl">Home</a></li>
+                <li class="active exact-active"><a href="/nl">Home</a></li>
                 <li><a href="/nl/disclaimer">Disclaimer</a></li>
                 <li><a href="/nl/disclaimer/intellectuele-eigendom">Intellectuële Eigendom</a></li>
             </ul>
@@ -295,7 +293,6 @@ class MenuSetActiveTest extends MenuTestCase
     public function it_can_render_a_custom_exact_active_class()
     {
         $this->menu = Menu::new()
-            ->setExactActive()
             ->setExactActiveClass('e-active')
             ->link('/', 'Home')
             ->link('/disclaimer', 'Disclaimer')
@@ -329,7 +326,7 @@ class MenuSetActiveTest extends MenuTestCase
         $this->assertRenders('
             <div>
                 <li><a href="/">Home</a></li>
-                <li class="active"><a href="/about">About</a></li>
+                <li class="active exact-active"><a href="/about">About</a></li>
             </div>
         ');
     }
@@ -349,7 +346,7 @@ class MenuSetActiveTest extends MenuTestCase
         $this->assertRenders('
             <ul>
                 <a href="/">Home</a>
-                <a href="/about" class="active">About</a>
+                <a href="/about" class="active exact-active">About</a>
             </ul>
         ');
     }
@@ -370,7 +367,7 @@ class MenuSetActiveTest extends MenuTestCase
         $this->assertRenders('
             <div>
                 <a href="/">Home</a>
-                <a href="/about" class="active">About</a>
+                <a href="/about" class="active exact-active">About</a>
             </div>
         ');
     }
@@ -395,7 +392,7 @@ class MenuSetActiveTest extends MenuTestCase
 
         $this->assertRenders('
             <ul class="navbar-nav">
-                <li class="active nav-item">
+                <li class="active exact-active nav-item">
                     <a href="/about" class="nav-link">About</a>
                 </li>
                 <li class="nav-item dropdown">
@@ -434,7 +431,7 @@ class MenuSetActiveTest extends MenuTestCase
                 <li class="active nav-item dropdown">
                     <a href="#" data-toggle="dropdown" class="nav-link dropdown-toggle">Dropdown link</a>
                     <div class="dropdown-menu">
-                        <a href="/about" class="dropdown-item active">About</a>
+                        <a href="/about" class="dropdown-item active exact-active">About</a>
                     </div>
                 </li>
             </ul>


### PR DESCRIPTION
```php
        $this->menu = Menu::new()
            ->setExactActive(true)
            ->link('/', 'Home')
            ->link('/people', 'People')
            ->link('/people/sebastian', 'Sebastian')
            ->setActive('/people/sebastian');
```
now renders to
```html
            <ul>
                <li><a href="/">Home</a></li>
                <li class="active"><a href="/people">People</a></li>
                <li class="active exact-active"><a href="/people/sebastian">Sebastian</a></li>
            </ul>
```

Tests are in 
* MenuSetActiveTest@it_can_set_items_exact_active
* MenuSetActiveTest@it_only_sets_exact_active_on_exact_url_match
* MenuSetActiveTest@it_can_render_a_custom_exact_active_class

Spatie\Menu\ExactUrlChecker is a clone of Spatie\Menu\ActiveUrlChecker, and only returns true if the url is an exact match.