### PR TITLE
Fix submenu inherited link class

### DIFF
--- a/src/Menu.php
+++ b/src/Menu.php
@@ -491,7 +491,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     public function addItemClass(string $class, bool $treatSubmenuAsLink = false)
     {
         $this->applyToAll(function (HasHtmlAttributes $link) use ($class, $treatSubmenuAsLink) {
-            if($treatSubmenuAsLink || ! $link instanceof self){
+            if ($treatSubmenuAsLink || ! $link instanceof self) {
                 $link->addClass($class);
             }
         });

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -479,16 +479,21 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
     }
 
     /**
-     * Add a class to all items in the menu.
+     * Add a class to all items in the menu, unless it's a submenu.
+     * If it is a submenu it will not have the item class unless it is
+     * overridden by setting $treatSubmenuAsLink to true.
      *
      * @param string $class
+     * @param boolean $treatSubmenuAsLink
      *
      * @return $this
      */
-    public function addItemClass(string $class)
+    public function addItemClass(string $class, bool $treatSubmenuAsLink = false)
     {
-        $this->applyToAll(function (HasHtmlAttributes $link) use ($class) {
-            $link->addClass($class);
+        $this->applyToAll(function (HasHtmlAttributes $link) use ($class, $treatSubmenuAsLink) {
+            if($treatSubmenuAsLink || ! $link instanceof self){
+                $link->addClass($class);
+            }
         });
 
         return $this;

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -484,7 +484,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes
      * overridden by setting $treatSubmenuAsLink to true.
      *
      * @param string $class
-     * @param boolean $treatSubmenuAsLink
+     * @param bool $treatSubmenuAsLink
      *
      * @return $this
      */

--- a/tests/MenuSubmenuTest.php
+++ b/tests/MenuSubmenuTest.php
@@ -90,7 +90,8 @@ class MenuSubmenuTest extends MenuTestCase
     }
 
     /** @test */
-    public function it_can_render_a_submenu_without_the_menu_item_class() {
+    public function it_can_render_a_submenu_without_the_menu_item_class()
+    {
         $this->menu = Menu::new()
             ->addClass('nav')
             ->addItemParentClass('nav-item')
@@ -100,8 +101,7 @@ class MenuSubmenuTest extends MenuTestCase
             ->link('#', 'Main Menu Link 2')
             ->submenu(
                 Link::to('#', 'Sub Menu')
-                    ->addClass('nav-link nav-dropdown-toggle')
-                ,
+                    ->addClass('nav-link nav-dropdown-toggle'),
                 Menu::new()
                     ->addClass('nav-dropdown-items') // this has nav-link class from parent menu but it shouldn't
                     ->addParentClass('nav-dropdown')
@@ -126,7 +126,8 @@ class MenuSubmenuTest extends MenuTestCase
     }
 
     /** @test */
-    public function it_can_render_a_submenu_with_the_menu_item_class_when_it_has_the_override_Set() {
+    public function it_can_render_a_submenu_with_the_menu_item_class_when_it_has_the_override_Set()
+    {
         $this->menu = Menu::new()
             ->addClass('nav')
             ->addItemParentClass('nav-item')
@@ -136,8 +137,7 @@ class MenuSubmenuTest extends MenuTestCase
             ->link('#', 'Main Menu Link 2')
             ->submenu(
                 Link::to('#', 'Sub Menu')
-                    ->addClass('nav-link nav-dropdown-toggle')
-                ,
+                    ->addClass('nav-link nav-dropdown-toggle'),
                 Menu::new()
                     ->addClass('nav-dropdown-items') // this has nav-link class from parent menu but it shouldn't
                     ->addParentClass('nav-dropdown')

--- a/tests/MenuSubmenuTest.php
+++ b/tests/MenuSubmenuTest.php
@@ -88,4 +88,76 @@ class MenuSubmenuTest extends MenuTestCase
 
         $this->assertRenders('<ul></ul>');
     }
+
+    /** @test */
+    public function it_can_render_a_submenu_without_the_menu_item_class() {
+        $this->menu = Menu::new()
+            ->addClass('nav')
+            ->addItemParentClass('nav-item')
+            ->addItemClass('nav-link')
+
+            ->link('#', 'Main Menu Link 1')
+            ->link('#', 'Main Menu Link 2')
+            ->submenu(
+                Link::to('#', 'Sub Menu')
+                    ->addClass('nav-link nav-dropdown-toggle')
+                ,
+                Menu::new()
+                    ->addClass('nav-dropdown-items') // this has nav-link class from parent menu but it shouldn't
+                    ->addParentClass('nav-dropdown')
+                    ->addItemParentClass('nav-item')
+                    ->addItemClass('nav-link')
+                    ->link('#', 'Sub Menu Item 1')
+                    ->link('#', 'Sub Menu Item 2')
+            );
+
+        $this->assertRenders('
+            <ul class="nav">
+                <li class="nav-item"><a href="#" class="nav-link">Main Menu Link 1</a></li>
+                <li class="nav-item"><a href="#" class="nav-link">Main Menu Link 2</a></li>
+                <li class="nav-dropdown nav-item"><a href="#" class="nav-link nav-dropdown-toggle">Sub Menu</a>
+                    <ul class="nav-dropdown-items">
+                        <li class="nav-item"><a href="#" class="nav-link">Sub Menu Item 1</a></li>
+                        <li class="nav-item"><a href="#" class="nav-link">Sub Menu Item 2</a></li>
+                    </ul>
+                </li>
+            </ul>
+        ');
+    }
+
+    /** @test */
+    public function it_can_render_a_submenu_with_the_menu_item_class_when_it_has_the_override_Set() {
+        $this->menu = Menu::new()
+            ->addClass('nav')
+            ->addItemParentClass('nav-item')
+            ->addItemClass('nav-link', true)
+
+            ->link('#', 'Main Menu Link 1')
+            ->link('#', 'Main Menu Link 2')
+            ->submenu(
+                Link::to('#', 'Sub Menu')
+                    ->addClass('nav-link nav-dropdown-toggle')
+                ,
+                Menu::new()
+                    ->addClass('nav-dropdown-items') // this has nav-link class from parent menu but it shouldn't
+                    ->addParentClass('nav-dropdown')
+                    ->addItemParentClass('nav-item')
+                    ->addItemClass('nav-link')
+                    ->link('#', 'Sub Menu Item 1')
+                    ->link('#', 'Sub Menu Item 2')
+            );
+
+        $this->assertRenders('
+            <ul class="nav">
+                <li class="nav-item"><a href="#" class="nav-link">Main Menu Link 1</a></li>
+                <li class="nav-item"><a href="#" class="nav-link">Main Menu Link 2</a></li>
+                <li class="nav-dropdown nav-item"><a href="#" class="nav-link nav-dropdown-toggle">Sub Menu</a>
+                    <ul class="nav-dropdown-items nav-link">
+                        <li class="nav-item"><a href="#" class="nav-link">Sub Menu Item 1</a></li>
+                        <li class="nav-item"><a href="#" class="nav-link">Sub Menu Item 2</a></li>
+                    </ul>
+                </li>
+            </ul>
+        ');
+    }
 }


### PR DESCRIPTION
Removed item link from submenu class

Modified the addItemClass to behave as expected, yet added an override in case there was a reason to have a submenu also inherit the item class. Added tests in the MenuSubmentuTest.php for both conditions.

Then fixed styleCI Conflicts