### PR TITLE
Fixes #78 ItemClass from parent menu cascades into submenu wrapper

### DIFF
--- a/src/Menu.php
+++ b/src/Menu.php
@@ -518,7 +518,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes, I
      */
     public function addItemClass(string $class)
     {
-        $this->applyToAll(function (HasHtmlAttributes $link) use ($class) {
+        $this->applyToAll(function (Link $link) use ($class) {
             $link->addClass($class);
         });
 

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -518,6 +518,22 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes, I
      */
     public function addItemClass(string $class)
     {
+        $this->applyToAll(function (HasHtmlAttributes $link) use ($class) {
+            $link->addClass($class);
+        });
+
+        return $this;
+    }
+
+    /**
+     * Add a class to all links in the menu.
+     *
+     * @param string $class
+     *
+     * @return $this
+     */
+    public function addLinkClass(string $class)
+    {
         $this->applyToAll(function (Link $link) use ($class) {
             $link->addClass($class);
         });

--- a/tests/MenuAddTest.php
+++ b/tests/MenuAddTest.php
@@ -199,9 +199,7 @@ class MenuAddTest extends MenuTestCase
             ->link('#', 'Main Menu Link 1')
             ->link('#', 'Main Menu Link 2')
             ->submenu(
-                Link::to('#', 'Sub Menu')
-                    ->addClass('nav-link nav-dropdown-toggle')
-                ,
+                Link::to('#', 'Sub Menu')->addClass('nav-link nav-dropdown-toggle'),
                 Menu::new()
                     ->addClass('nav-dropdown-items') // this has nav-link class from parent menu but it shouldn't
                     ->addParentClass('nav-dropdown')

--- a/tests/MenuAddTest.php
+++ b/tests/MenuAddTest.php
@@ -188,4 +188,42 @@ class MenuAddTest extends MenuTestCase
             </ul>
         ');
     }
+
+    /** @test */
+    public function it_will_only_add_classes_to_all_links_in_the_menu_not_submenus()
+    {
+        $this->menu = Menu::new()
+            ->addClass('nav')
+            ->addItemParentClass('nav-item')
+            ->addItemClass('nav-link')
+            ->link('#', 'Main Menu Link 1')
+            ->link('#', 'Main Menu Link 2')
+            ->submenu(
+                Link::to('#', 'Sub Menu')
+                    ->addClass('nav-link nav-dropdown-toggle')
+                ,
+                Menu::new()
+                    ->addClass('nav-dropdown-items') // this has nav-link class from parent menu but it shouldn't
+                    ->addParentClass('nav-dropdown')
+                    ->addItemParentClass('nav-item')
+                    ->addItemClass('nav-link')
+                    ->link('#', 'Sub Menu Item 1')
+                    ->link('#', 'Sub Menu Item 2')
+            );
+
+        $this->menu->render();
+
+        $this->assertRenders('
+            <ul class="nav">
+                <li class="nav-item"><a href="#" class="nav-link">Main Menu Link 1</a></li>
+                <li class="nav-item"><a href="#" class="nav-link">Main Menu Link 2</a></li>
+                <li class="nav-dropdown nav-item"><a href="#" class="nav-link nav-dropdown-toggle">Sub Menu</a>
+                    <ul class="nav-dropdown-items">
+                        <li class="nav-item"><a href="#" class="nav-link">Sub Menu Item 1</a></li>
+                        <li class="nav-item"><a href="#" class="nav-link">Sub Menu Item 2</a></li>
+                    </ul>
+                </li>
+            </ul>
+        ');
+    }
 }

--- a/tests/MenuAddTest.php
+++ b/tests/MenuAddTest.php
@@ -190,12 +190,12 @@ class MenuAddTest extends MenuTestCase
     }
 
     /** @test */
-    public function it_will_only_add_classes_to_all_links_in_the_menu_not_submenus()
+    public function it_will_only_add_classes_to_links_in_the_menu_and_not_submenus_or_items()
     {
         $this->menu = Menu::new()
             ->addClass('nav')
             ->addItemParentClass('nav-item')
-            ->addItemClass('nav-link')
+            ->addLinkClass('nav-link')
             ->link('#', 'Main Menu Link 1')
             ->link('#', 'Main Menu Link 2')
             ->submenu(


### PR DESCRIPTION
When adding an "item class" on an instance of `\Spatie\Menu\Menu` via `addItemClass()`, it's possible for menus and links to have the "item class" applied. Since the `\Spatie\Menu\Menu` class also implements `\Spatie\Menu\HasHtmlAttributes` interface, all links as well as submenus get the applied class.