### PR TITLE
feat: addclass accept parameter 'class' of type string and array

### DIFF
--- a/src/HasHtmlAttributes.php
+++ b/src/HasHtmlAttributes.php
@@ -20,9 +20,10 @@ interface HasHtmlAttributes
     public function setAttributes(array $attributes);
 
     /**
-     * @param string $class
+     * @param string|array $class
      *
      * @return $this
      */
-    public function addClass(string $class);
+    public function addClass($class);
 }
+

--- a/src/HasParentAttributes.php
+++ b/src/HasParentAttributes.php
@@ -28,9 +28,9 @@ interface HasParentAttributes
     public function setParentAttributes(array $attributes);
 
     /**
-     * @param string $class
+     * @param string|array $class
      *
      * @return $this
      */
-    public function addParentClass(string $class);
+    public function addParentClass($class);
 }

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -512,11 +512,11 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes, I
     /**
      * Add a class to all items in the menu.
      *
-     * @param string $class
+     * @param string|array $class
      *
      * @return $this
      */
-    public function addItemClass(string $class)
+    public function addItemClass($class)
     {
         $this->applyToAll(function (HasHtmlAttributes $link) use ($class) {
             $link->addClass($class);
@@ -545,11 +545,11 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes, I
     /**
      * Add a parent class to all items in the menu.
      *
-     * @param string $class
+     * @param string|array $class
      *
      * @return $this
      */
-    public function addItemParentClass(string $class)
+    public function addItemParentClass($class)
     {
         $this->applyToAll(function (HasParentAttributes $item) use ($class) {
             $item->addParentClass($class);

--- a/src/Traits/HasHtmlAttributes.php
+++ b/src/Traits/HasHtmlAttributes.php
@@ -35,14 +35,15 @@ trait HasHtmlAttributes
     }
 
     /**
-     * @param string $class
+     * @param string|array $class
      *
      * @return $this
      */
-    public function addClass(string $class)
+    public function addClass($class)
     {
         $this->htmlAttributes->addClass($class);
 
         return $this;
     }
 }
+

--- a/src/Traits/HasParentAttributes.php
+++ b/src/Traits/HasParentAttributes.php
@@ -46,11 +46,11 @@ trait HasParentAttributes
     }
 
     /**
-     * @param string $class
+     * @param string|array $class
      *
      * @return $this
      */
-    public function addParentClass(string $class)
+    public function addParentClass($class)
     {
         $this->parentAttributes->addClass($class);
 


### PR DESCRIPTION
In the file src/Html/Attribute.php the function 'addClass($class)' accept attribute type "string" and "array" but the same function in 'addClass($class)' in src/Traits/HasAttributes.php which calls the first 'addClass' in Attribute.php only accept "string" and this contradicts the documentation in [https://docs.spatie.be/menu/v2/controlling-the-html-output/item-attributes](https://docs.spatie.be/menu/v2/controlling-the-html-output/item-attributes) where it says "The setAttribute and addClass methods are smart enough to merge class names on render. The latter can also **accepts both arrays and strings**."