### PR TITLE
don't wrap predecessor of elements - fixes #91

### DIFF
--- a/src/Menu.php
+++ b/src/Menu.php
@@ -693,11 +693,11 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes, I
 
         $wrappedContents = $tag ? $tag->withContents($contents) : implode('', $contents);
 
-        $menu = $this->prepend.$wrappedContents.$this->append;
-
         if (! empty($this->wrap)) {
-            return Tag::make($this->wrap[0], new Attributes($this->wrap[1]))->withContents($menu);
+            $wrappedContents = Tag::make($this->wrap[0], new Attributes($this->wrap[1]))->withContents($wrappedContents);
         }
+
+        $menu = $this->prepend . $wrappedContents . $this->append;
 
         return $menu;
     }

--- a/tests/MenuExtraHtmlTest.php
+++ b/tests/MenuExtraHtmlTest.php
@@ -221,4 +221,36 @@ class MenuExtraHtmlTest extends MenuTestCase
             </ul>
         ');
     }
+
+    /** @test */
+    public function it_wraps_submenu_with_header_element()
+    {
+
+        $submenu = Menu::new()
+            ->link('#', 'SubMenu Item 1')
+            ->link('#', 'SubMenu Item 2')
+            ->wrap( 'div', ['class' => 'someclass'] );
+
+        $this->menu = Menu::new()
+            ->link('#', 'Menu Item 1')
+            ->link('#', 'Menu Item 2')
+            ->submenu(Link::to('#', 'Menu Item 3'), $submenu);
+
+        $this->assertRenders('
+            <ul>
+                <li><a href="#">Menu Item 1</a></li>
+                <li><a href="#">Menu Item 2</a></li>
+                <li><a href="#">Menu Item 3</a>
+                    <div class="someclass">
+                        <ul>
+                            <li><a href="#">SubMenu Item 1</a></li>
+                            <li><a href="#">SubMenu Item 2</a></li>
+                        </ul>
+                    </div>
+                </li>
+            </ul>
+        ');
+
+    }
+
 }


### PR DESCRIPTION
This works and existing tests don't break, hopefully I didn't miss something else.

I **did not** try to mess with any of the js manipulation mentioned in issue #91
