### PR TITLE
Update ActiveUrlChecker.php

### DIFF
--- a/src/ActiveUrlChecker.php
+++ b/src/ActiveUrlChecker.php
@@ -39,7 +39,7 @@ class ActiveUrlChecker
         $matchPath = Str::removeFromStart($rootUrl, $matchPath);
 
         // If this url starts with the url we're matching with, it's active.
-        if ($matchPath === $itemPath || Str::startsWith($matchPath, $itemPath)) {
+        if ($matchPath === $itemPath || Str::startsWith($itemPath, $matchPath)) {
             return true;
         }
 


### PR DESCRIPTION
A parent menu entry of a submenu does not get marked as active properly. This is most likely due to a wrong argument order in ActiveUrlChecker.php line 42:

```php
...
// If this url starts with the url we're matching with, it's active.
        if ($matchPath === $itemPath || Str::startsWith($matchPath, $itemPath)) {
            return true;
        }
...
```

should be

```php
...
// If this url starts with the url we're matching with, it's active.
        if ($matchPath === $itemPath || Str::startsWith($itemPath, $matchPath)) {
            return true;
        }
...
```