### PR TITLE
Absolute and Relative URLs

### DIFF
--- a/tests/MenuSetActiveTest.php
+++ b/tests/MenuSetActiveTest.php
@@ -282,6 +282,50 @@ class MenuSetActiveTest extends MenuTestCase
     }
 
     /** @test */
+    public function it_can_set_relative_items_active_from_absolute_urls()
+    {
+        $this->menu = Menu::new()
+            ->link('/', 'Home')
+            ->link('/disclaimer', 'Disclaimer')
+            ->link('/disclaimer/intellectual-property', 'Intellectual Property')
+            ->setActive('http://example.com/disclaimer');
+
+        $this->assertRenders('
+            <ul>
+                <li><a href="/">Home</a></li>
+                <li class="active exact-active">
+                    <a href="/disclaimer">Disclaimer</a>
+                </li>
+                <li>
+                    <a href="/disclaimer/intellectual-property">Intellectual Property</a>
+                </li>
+            </ul>
+        ');
+    }
+
+    /** @test */
+    public function it_can_set_absolute_items_active_from_relative_urls()
+    {
+        $this->menu = Menu::new()
+            ->link('http://example.com/', 'Home')
+            ->link('http://example.com/disclaimer', 'Disclaimer')
+            ->link('http://example.com/disclaimer/intellectual-property', 'Intellectual Property')
+            ->setActive('/disclaimer');
+
+        $this->assertRenders('
+            <ul>
+                <li><a href="http://example.com/">Home</a></li>
+                <li class="active exact-active">
+                    <a href="http://example.com/disclaimer">Disclaimer</a>
+                </li>
+                <li>
+                    <a href="http://example.com/disclaimer/intellectual-property">Intellectual Property</a>
+                </li>
+            </ul>
+        ');
+    }
+
+    /** @test */
     public function it_doesnt_set_items_active_if_the_paths_match_but_they_have_a_different_domain()
     {
         $this->menu = Menu::new()


### PR DESCRIPTION
Under "Determining the Active Items with a URL" the docs state:

> Mixing absolute and relative url's isn't an issue either.

However I am finding that not to be the case. I am working on a CodeIgniter 4 adaptation of this library and I am initializing the instance to what the framework knows as the current and base URLs. The problem is that choosing the absolute/relative path forces the implementor into using the same.

This PR adds two tests which demonstrate the issue. I would be willing to dig into the source and try to find a fix, but want to make sure these failures are indeed "bugs" before putting work into it.

*Note: I worked on this in `v2` locally but the issue is happening against `master` as well in my Github Actions for PHP 8.*