### PR TITLE
Update spatie/url dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php" : "^8.0",
-        "spatie/url": "^1.0.0"
+        "spatie/url": "^2.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
I came across this outdated dependency when checking `composer outdated` for a project that is using `spatie/laravel-menu`. I think this can be merged without any backwards compatibility changes.