### PR TITLE
typofix in item-attributes.md

### DIFF
--- a/docs/controlling-the-html-output/item-attributes.md
+++ b/docs/controlling-the-html-output/item-attributes.md
@@ -22,7 +22,7 @@ The `setAttribute` and `addClass` methods are smart enough to merge class names 
 ```php
 Link::to('#', 'Back to top')
     ->setAttribute('class', 'link')
-    ->addClasses(['button', 'top']);
+    ->addClass(['button', 'top']);
 ```
 
 ```html


### PR DESCRIPTION
The only method in src/Traits/HasHtmlAttributes.php is addClass. 

Apart from that, I think this doc is wrong because addClass doesn't accept an array as argument. ¿Should this info be deleted from the docs, or am I missing something?