### PR TITLE
Fix wrapping in Bootstrap menu code example

### DIFF
--- a/docs/examples/bootstrap-menu.md
+++ b/docs/examples/bootstrap-menu.md
@@ -23,22 +23,24 @@ Menu::new()
 ```
 
 ```html
-<ul class="nav navbar-nav">
-    <li class="active">
-        <a href="/one">One</a>
-    </li>
-    <li>
-        <a href="/two">Two</a>
-    </li>
-    <li>
-        <a href="#" data-toggle="dropdown" role="button" class="dropdown-toggle">
-            Dropdown <span class="caret"></span>
-        </a>
-        <ul class="dropdown-menu">
-            <li><a href="#">Action</a></li>
-            <li><a href="#">Another action</a></li>
-            <li role="separator" class="divider"></li>
-        </ul>
-    </li>
-</ul>
+<div class="collapse navbar-collapse">
+    <ul class="nav navbar-nav">
+        <li class="active">
+            <a href="/one">One</a>
+        </li>
+        <li>
+            <a href="/two">Two</a>
+        </li>
+        <li>
+            <a href="#" data-toggle="dropdown" role="button" class="dropdown-toggle">
+                Dropdown <span class="caret"></span>
+            </a>
+            <ul class="dropdown-menu">
+                <li><a href="#">Action</a></li>
+                <li><a href="#">Another action</a></li>
+                <li role="separator" class="divider"></li>
+            </ul>
+        </li>
+    </ul>
+</div>
 ```


### PR DESCRIPTION
Element and classes added in the wrap() method are not reflected in the resulting HTML code. This commit fixes the issue.