### PR TITLE
refactor: simplify isActive() by combining prepend check into return

### DIFF
--- a/src/Menu.php
+++ b/src/Menu.php
@@ -363,11 +363,7 @@ class Menu implements Item, Countable, HasHtmlAttributes, HasParentAttributes, I
             }
         }
 
-        if ($this->prepend && $this->prepend instanceof Item && $this->prepend->isActive()) {
-            return true;
-        }
-
-        return false;
+        return $this->prepend instanceof Item && $this->prepend->isActive();
     }
 
     /**


### PR DESCRIPTION
The separate if condition for prepend check is redundant since we can directly return the combined boolean expression